### PR TITLE
Multi-client and dynamic acceptor modes on jspurefix 5.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,5 @@ store/
 
 # local jspurefix tarball builds
 *.tgz
-jsfix.test_client_*.txt
+# generated FIX logs - one per session, named after the application/counterparty
+jsfix.*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ data/fix_repo
 /jsfix.test_server.txt
 capture.txt
 store/
+
+# local jspurefix tarball builds
+*.tgz
+jsfix.test_client_*.txt

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The demo supports three session modes that control store type and sequence reset
 | `recovery` | file | N (both) | 2345 | Sequences persist across restarts. Resume where left off. |
 | `broker-reset` | file | server=Y, client=N | 2346 | Server forces reset (simulates daily broker reset). Client wants resume but respects server reset. |
 | `multi-client` | file | N (both) | 2345 | Acceptor runs `TargetCompID: "*"`. Several clients share one listener, each with its own identity and store. |
+| `dynamic` | file | N (both) | 2347 | Same wildcard acceptor, but the counterparties are unrelated names it has never been configured with — including one that joins after startup. |
 | `clear` | — | — | — | Delete every store directory and exit. |
 
 ```bash
@@ -41,6 +42,7 @@ npm run tcp-tc              # reset mode (default)
 npm run recovery            # recovery mode (file store)
 npm run broker-reset        # broker-reset mode
 npm run multi-client        # three clients against one wildcard acceptor
+npm run dynamic             # counterparties the venue has never heard of
 npm run clear               # wipe the stores
 ```
 
@@ -52,13 +54,15 @@ In recovery and broker-reset modes, a QuickFix-compatible file store is created 
 Usage: jspf-demo [options] [mode]
 
 Arguments:
-  mode                          session mode: reset, recovery, broker-reset, multi-client, clear
+  mode                          session mode: reset, recovery, broker-reset, multi-client, dynamic, clear
 
 Options:
   --client                      run initiator (client) only
   --server                      run acceptor (server) only
   --clients <n>                 number of clients to spawn, 1-5 (multi-client acceptor testing)
   --store <dir>                 override the store directory from the session config
+  --counterparties <names>      dynamic mode: comma separated SenderCompIds to connect
+  --late-join-after <seconds>   dynamic mode: seconds before an unseen counterparty joins (0 disables)
   --timeout <seconds>           shutdown after N seconds
   --disconnect-after <seconds>  disconnect client after N seconds (reconnect testing)
   -h, --help                    display help for command
@@ -83,6 +87,58 @@ node dist/trade_capture/app.js recovery --server --timeout 30
 # Three clients against one wildcard acceptor
 node dist/trade_capture/app.js multi-client --clients 3 --timeout 25
 ```
+
+## Dynamic acceptor — counterparties known only at logon
+
+`dynamic` mode is the one to run if you want to see what `TargetCompID: "*"` buys
+you. The acceptor is configured as a venue and nothing else:
+
+```json
+{
+  "SenderCompId": "venue",
+  "TargetCompID": "*"
+}
+```
+
+No counterparty appears anywhere in its configuration. Four then connect — three at
+startup, and `prop-desk-d` eight seconds later, with no restart and no config
+change:
+
+```
+wildcard acceptor: binding session identity to peer SenderCompID 'hedge-fund-a'
+accepted counterparty 'hedge-fund-a' (user js-client) - session is now venue -> hedge-fund-a
+...
+  >>> previously unseen counterparty 'prop-desk-d' is connecting now
+wildcard acceptor: binding session identity to peer SenderCompID 'prop-desk-d'
+```
+
+and the venue ends the run holding one persisted session per counterparty it met:
+
+```
+  the venue now holds a session store per counterparty it met:
+    FIX4.4-venue-hedge-fund-a.seqnums     [15 : 4]
+    FIX4.4-venue-market-maker-b.seqnums   [16 : 4]
+    FIX4.4-venue-prop-desk-d.seqnums      [15 : 4]
+    FIX4.4-venue-retail-broker-c.seqnums  [14 : 4]
+
+  none of those names appear anywhere in the acceptor configuration.
+```
+
+Each of those is a full FIX session: its own sequence numbers, its own resend
+history, recovered independently on reconnect. That is the difference between a
+wildcard that only fixes the outbound header and one that binds a real identity —
+the acceptor defers building its `SessionId` and store until the Logon tells it who
+the peer is.
+
+Bring your own names:
+
+```bash
+node dist/trade_capture/app.js dynamic --counterparties acme-capital,zeta-trading
+node dist/trade_capture/app.js dynamic --late-join-after 0     # disable the late joiner
+```
+
+Note the demo's `onLogon` does nothing but log. There is no `addCompIdMapping` call
+and no per-counterparty wiring — adopting the identity is the engine's job.
 
 ## Multiple clients on one acceptor
 
@@ -119,6 +175,7 @@ asserting on the persisted sequence files afterwards.
 ./scripts/test-scenarios.sh server-bounce      # server restarts, both recover from store
 ./scripts/test-scenarios.sh broker-reset       # server forces ResetSeqNumFlag=Y
 ./scripts/test-scenarios.sh multi-client       # 3 clients, 3 identities, 3 stores
+./scripts/test-scenarios.sh dynamic            # unknown counterparties adopted at logon
 ./scripts/test-scenarios.sh stale-transport    # half-open socket reconnect (jspurefix#153)
 ./scripts/test-scenarios.sh all
 ```
@@ -134,11 +191,6 @@ forget), so on restart the client sees a sequence number below what it has alrea
 recorded and drops the session. This reproduces on published jspurefix 5.8.5 too,
 so it is not a regression from the multi-client work — it needs a separate fix in
 the engine's store flush path.
-
-> **Note:** `multi-client` and `stale-transport` need the wildcard `TargetCompID`
-> and session registry support added to jspurefix after 5.8.5. Until that is
-> released, build the engine locally and install it with `npm run use:local` (see
-> below).
 
 ## Working against an unpublished jspurefix
 
@@ -179,6 +231,7 @@ data/session/
   recovery-*.json           — recovery mode configs (file store, no reset)
   broker-reset-*.json       — broker-reset mode configs (server forces reset)
   multi-client-*.json       — multi-client configs (acceptor uses TargetCompID "*")
+  dynamic-*.json            — dynamic acceptor configs (venue + unknown counterparties)
 
 scripts/
   test-scenarios.sh         — recovery and multi-client scenario runner

--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ The demo supports three session modes that control store type and sequence reset
 | `reset` (default) | memory | Y (both) | 2344 | Sequences reset on every logon. Stateless. |
 | `recovery` | file | N (both) | 2345 | Sequences persist across restarts. Resume where left off. |
 | `broker-reset` | file | server=Y, client=N | 2346 | Server forces reset (simulates daily broker reset). Client wants resume but respects server reset. |
+| `multi-client` | file | N (both) | 2345 | Acceptor runs `TargetCompID: "*"`. Several clients share one listener, each with its own identity and store. |
+| `clear` | — | — | — | Delete every store directory and exit. |
 
 ```bash
 npm run tcp-tc              # reset mode (default)
 npm run recovery            # recovery mode (file store)
 npm run broker-reset        # broker-reset mode
+npm run multi-client        # three clients against one wildcard acceptor
+npm run clear               # wipe the stores
 ```
 
 In recovery and broker-reset modes, a QuickFix-compatible file store is created under `store/` with `.seqnums`, `.body`, and `.header` files.
@@ -48,11 +52,13 @@ In recovery and broker-reset modes, a QuickFix-compatible file store is created 
 Usage: jspf-demo [options] [mode]
 
 Arguments:
-  mode                          session mode: reset (default), recovery, broker-reset
+  mode                          session mode: reset, recovery, broker-reset, multi-client, clear
 
 Options:
   --client                      run initiator (client) only
   --server                      run acceptor (server) only
+  --clients <n>                 number of clients to spawn, 1-5 (multi-client acceptor testing)
+  --store <dir>                 override the store directory from the session config
   --timeout <seconds>           shutdown after N seconds
   --disconnect-after <seconds>  disconnect client after N seconds (reconnect testing)
   -h, --help                    display help for command
@@ -73,7 +79,80 @@ node dist/trade_capture/app.js --disconnect-after 5
 
 # Server-only with timeout
 node dist/trade_capture/app.js recovery --server --timeout 30
+
+# Three clients against one wildcard acceptor
+node dist/trade_capture/app.js multi-client --clients 3 --timeout 25
 ```
+
+## Multiple clients on one acceptor
+
+`multi-client` mode is the reference setup for an acceptor serving several
+counterparties. The acceptor config sets `"TargetCompID": "*"`, so it does not have
+to know its counterparties in advance — each accepted connection adopts the
+`SenderCompID` from that client's Logon, and from it derives:
+
+- its own `SessionId`, and therefore its own store files under `store/multi-acceptor/`
+- its own entry in the engine's session registry
+- its own log prefix, e.g. `[test_server:init-comp_2:FixSession]`
+
+Each spawned client gets a `_1.._n` suffix on its `SenderCompId` so the acceptor
+sees genuinely distinct counterparties. The server log carries a census line
+whenever the population changes:
+
+```
+[acceptor] info: acceptor census: transports=3 [1@::1:55641 up 1s, 2@::1:55642 up 0s, 3@::1:55643 up 0s]
+                 sessions=2 [FIX4.4-accept-comp-init-comp_1, FIX4.4-accept-comp-init-comp_2]
+```
+
+If the same counterparty reconnects while its previous socket is still open — the
+half-open socket case in
+[jspurefix#153](https://github.com/TimelordUK/jspurefix/issues/153) — the registry
+stops the stale session so only one remains per CompID pair.
+
+## Test scenarios
+
+`scripts/test-scenarios.sh` drives the demo through the recovery cases that matter,
+asserting on the persisted sequence files afterwards.
+
+```bash
+./scripts/test-scenarios.sh client-bounce      # client restarts, server keeps running
+./scripts/test-scenarios.sh server-bounce      # server restarts, both recover from store
+./scripts/test-scenarios.sh broker-reset       # server forces ResetSeqNumFlag=Y
+./scripts/test-scenarios.sh multi-client       # 3 clients, 3 identities, 3 stores
+./scripts/test-scenarios.sh stale-transport    # half-open socket reconnect (jspurefix#153)
+./scripts/test-scenarios.sh all
+```
+
+`stale-transport` uses `scripts/stale-transport.js`, which plays the counterparty
+directly over a raw socket: it logs on, then stops participating without ever
+closing. Killing a process would not reproduce this — the kernel still closes its
+file descriptors — so the script holds the socket open itself.
+
+**Known failure:** `server-bounce` does not currently pass. The acceptor's persisted
+sender sequence lags what it actually sent (message store writes are fire and
+forget), so on restart the client sees a sequence number below what it has already
+recorded and drops the session. This reproduces on published jspurefix 5.8.5 too,
+so it is not a regression from the multi-client work — it needs a separate fix in
+the engine's store flush path.
+
+> **Note:** `multi-client` and `stale-transport` need the wildcard `TargetCompID`
+> and session registry support added to jspurefix after 5.8.5. Until that is
+> released, build the engine locally and install it with `npm run use:local` (see
+> below).
+
+## Working against an unpublished jspurefix
+
+To test engine changes without publishing to npm:
+
+```bash
+cd ../jspurefix && npm run pack:local   # builds and packs to ../.local-packages
+cd ../jspf-demo && npm run use:local    # install that tarball
+npm run use:npm                         # go back to the registry version
+```
+
+A tarball rather than `npm link` on purpose: a symlinked dependency loads its own
+copy of `reflect-metadata` and `tsyringe`, and two decorator metadata registries
+means tsyringe silently fails to resolve anything registered through the other one.
 
 ## Session resilience
 
@@ -99,6 +178,11 @@ data/session/
   test-acceptor.json        — reset mode server config
   recovery-*.json           — recovery mode configs (file store, no reset)
   broker-reset-*.json       — broker-reset mode configs (server forces reset)
+  multi-client-*.json       — multi-client configs (acceptor uses TargetCompID "*")
+
+scripts/
+  test-scenarios.sh         — recovery and multi-client scenario runner
+  stale-transport.js        — raw-socket counterparty for the half-open reconnect case
 ```
 
 ## Parsing FIX logs

--- a/data/session/dynamic-acceptor.json
+++ b/data/session/dynamic-acceptor.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "type": "acceptor",
+    "name": "venue",
+    "tcp": {
+      "host": "localhost",
+      "port": 2347,
+      "keepAliveMs": 10000
+    },
+    "protocol": "ascii",
+    "dictionary": "qf44"
+  },
+  "store": {
+    "type": "file",
+    "directory": "store/dynamic-acceptor"
+  },
+  "Username": "js-server",
+  "Password": "pwd-server",
+  "EncryptMethod": 0,
+  "ResetSeqNumFlag": false,
+  "HeartBtInt": 30,
+  "SenderCompId": "venue",
+  "TargetCompID": "*",
+  "TargetSubID": "fix",
+  "BeginString": "FIX4.4"
+}

--- a/data/session/dynamic-initiator.json
+++ b/data/session/dynamic-initiator.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "reconnectSeconds": 10,
+    "type": "initiator",
+    "name": "counterparty",
+    "tcp": {
+      "host": "localhost",
+      "port": 2347
+    },
+    "protocol": "ascii",
+    "dictionary": "qf44"
+  },
+  "store": {
+    "type": "file",
+    "directory": "store/dynamic-initiator"
+  },
+  "Username": "js-client",
+  "Password": "pwd-client",
+  "EncryptMethod": 0,
+  "ResetSeqNumFlag": false,
+  "HeartBtInt": 30,
+  "SenderCompId": "counterparty",
+  "TargetCompID": "venue",
+  "TargetSubID": "fix",
+  "BeginString": "FIX4.4"
+}

--- a/data/session/multi-client-acceptor.json
+++ b/data/session/multi-client-acceptor.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "type": "acceptor",
+    "name": "test_server",
+    "tcp": {
+      "host": "localhost",
+      "port": 2345,
+      "keepAliveMs": 10000
+    },
+    "protocol": "ascii",
+    "dictionary": "qf44"
+  },
+  "store": {
+    "type": "file",
+    "directory": "store/multi-acceptor"
+  },
+  "Username": "js-server",
+  "Password": "pwd-server",
+  "EncryptMethod": 0,
+  "ResetSeqNumFlag": false,
+  "HeartBtInt": 30,
+  "SenderCompId": "accept-comp",
+  "TargetCompID": "*",
+  "TargetSubID": "fix",
+  "BeginString": "FIX4.4"
+}

--- a/data/session/multi-client-initiator.json
+++ b/data/session/multi-client-initiator.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "reconnectSeconds": 10,
+    "type": "initiator",
+    "name": "test_client",
+    "tcp": {
+      "host": "localhost",
+      "port": 2345
+    },
+    "protocol": "ascii",
+    "dictionary": "qf44"
+  },
+  "store": {
+    "type": "file",
+    "directory": "store/multi-initiator"
+  },
+  "Username": "js-client",
+  "Password": "pwd-client",
+  "EncryptMethod": 0,
+  "ResetSeqNumFlag": false,
+  "HeartBtInt": 30,
+  "SenderCompId": "init-comp",
+  "TargetCompID": "accept-comp",
+  "TargetSubID": "fix",
+  "BeginString": "FIX4.4"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "commander": "^15.0.0",
-        "jspurefix": "^5.8.5",
+        "jspurefix": "^5.9.1",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
@@ -29,7 +29,9 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -43,7 +45,9 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -52,7 +56,9 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -82,7 +88,9 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -91,7 +99,9 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -107,7 +117,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -123,7 +135,9 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -132,7 +146,9 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -141,7 +157,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -154,7 +172,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -171,7 +191,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -180,6 +202,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -189,6 +212,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -198,7 +222,9 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -207,7 +233,9 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.29.0"
@@ -220,6 +248,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -235,7 +264,9 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -247,7 +278,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -259,7 +292,9 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -271,7 +306,9 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -286,7 +323,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -301,7 +340,9 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -313,7 +354,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -325,7 +368,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -340,7 +385,9 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -352,7 +399,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -364,7 +413,9 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -376,7 +427,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -388,7 +441,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -400,7 +455,9 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -412,7 +469,9 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -427,7 +486,9 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -442,7 +503,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -466,7 +529,9 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -480,7 +545,9 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -498,6 +565,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -862,7 +930,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -878,7 +948,9 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -887,7 +959,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -900,7 +974,9 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -913,7 +989,9 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -925,7 +1003,9 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -940,7 +1020,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -952,7 +1034,9 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -961,7 +1045,9 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1185,7 +1271,9 @@
       "version": "30.1.0",
       "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -1398,7 +1486,9 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1408,7 +1498,9 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1418,7 +1510,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1427,13 +1521,16 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1469,7 +1566,9 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -1488,13 +1587,17 @@
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1503,7 +1606,9 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
       "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -1710,13 +1815,17 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1725,7 +1834,9 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1755,6 +1866,7 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1774,7 +1886,9 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -1786,7 +1900,9 @@
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1795,7 +1911,9 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -2083,7 +2201,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2548,6 +2668,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2570,7 +2691,9 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2583,7 +2706,9 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -2785,13 +2910,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -2823,7 +2948,9 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -2856,7 +2983,9 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -2900,6 +3029,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -2927,7 +3057,9 @@
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
       "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -2988,6 +3120,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2998,6 +3131,7 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3013,6 +3147,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3044,7 +3179,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -3072,15 +3209,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3162,7 +3290,9 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3171,6 +3301,7 @@
       "version": "1.0.30001782",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
       "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3185,12 +3316,14 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3218,6 +3351,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3225,6 +3359,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3394,6 +3529,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3406,6 +3542,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -3495,6 +3632,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -3523,7 +3661,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -3972,7 +4112,9 @@
       "version": "1.5.329",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
       "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -4198,7 +4340,9 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4615,6 +4759,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4803,6 +4948,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4816,7 +4962,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -5110,18 +5258,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -5180,7 +5332,9 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5245,7 +5399,9 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5441,6 +5597,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -5482,6 +5639,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5696,6 +5854,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -5706,7 +5865,9 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6269,7 +6430,9 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6278,7 +6441,9 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -6990,7 +7155,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -7009,7 +7176,9 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7050,6 +7219,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -7064,15 +7234,14 @@
       "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ=="
     },
     "node_modules/jspurefix": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/jspurefix/-/jspurefix-5.8.5.tgz",
-      "integrity": "sha512-QKrcn/jyyGHMpu7nP9jGaGVmB81aKen4umOa6p4KRMt9mU3cpS6oavMOWsA4rtdU4eQ4LIM4PA4Gip482b2Ccw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/jspurefix/-/jspurefix-5.9.1.tgz",
+      "integrity": "sha512-unjwzqgqYTUO38Qta81GHdnqQ2yWVbt+HIhCfm9ywCO+b2rc7FLAozNxvIWnfSQMtnr+BBl/u2/z6ukAMoInzA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/globals": "^30.4.1",
         "align-text": "^1.0.2",
-        "axios": "^1.16.1",
+        "axios": "^1.19.0",
         "express": "^5.2.1",
         "lodash": "^4.18.1",
         "mathjs": "^15.2.0",
@@ -7081,397 +7250,11 @@
         "moment": "^2.30.1",
         "node-fs-extra": "^0.8.2",
         "reflect-metadata": "^0.2.2",
-        "sax": "^1.6.0",
+        "sax": "^1.6.1",
         "tsyringe": "^4.10.0",
         "winston": "^3.19.0",
         "word-wrap": "^1.2.5",
-        "yauzl": "^3.3.1"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/environment": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
-      "license": "MIT",
-      "dependencies": {
-        "expect": "30.4.1",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/fake-timers": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@types/node": "*",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/globals": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/types": "30.4.1",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/snapshot-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/transform": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jspurefix/node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-haste-map": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-snapshot": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@babel/generator": "^7.27.5",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1",
-        "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-preset-current-node-syntax": "^1.2.0",
-        "chalk": "^4.1.2",
-        "expect": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1",
-        "semver": "^7.7.2",
-        "synckit": "^0.11.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/jest-worker": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
-      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.4.1",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jspurefix/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "yauzl": "^3.4.0"
       }
     },
     "node_modules/keyv": {
@@ -7615,7 +7398,9 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -7707,7 +7492,9 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -7769,7 +7556,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -7810,6 +7599,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7968,6 +7758,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ncp": {
@@ -8010,13 +7801,17 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-source-walk": {
       "version": "7.0.1",
@@ -8035,7 +7830,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8315,7 +8112,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8364,6 +8163,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8373,7 +8173,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8441,12 +8243,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8459,7 +8263,9 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -8831,20 +8637,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -9198,9 +8990,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9216,6 +9008,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9423,7 +9216,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -9435,7 +9230,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9476,7 +9273,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -9491,7 +9290,9 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -9503,7 +9304,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9841,6 +9644,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9866,7 +9670,9 @@
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
       "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.9"
       },
@@ -9895,7 +9701,9 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -9910,7 +9718,9 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9959,7 +9769,9 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "license": "BSD-3-Clause"
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -10155,7 +9967,9 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10367,6 +10181,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -10418,6 +10233,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10433,6 +10249,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -10499,7 +10316,9 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -10783,7 +10602,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -10807,7 +10628,9 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -10889,12 +10712,11 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
-      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "scripts": {
     "build": "tsc",
+    "use:local": "npm install \"../.local-packages/jspurefix-local.tgz\"",
+    "use:npm": "npm install jspurefix@latest",
     "tcp-tc": "node dist/trade_capture/app.js",
     "server": "node dist/trade_capture/app.js --server",
     "client": "node dist/trade_capture/app.js --client",
@@ -20,6 +22,9 @@
     "recovery:server": "node dist/trade_capture/app.js recovery --server",
     "recovery:client": "node dist/trade_capture/app.js recovery --client",
     "broker-reset": "node dist/trade_capture/app.js broker-reset",
+    "multi-client": "node dist/trade_capture/app.js multi-client --clients 3",
+    "clear": "node dist/trade_capture/app.js clear",
+    "scenarios": "bash scripts/test-scenarios.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
     "parse-client-objects": "node node_modules/jspurefix/dist/jsfix-cmd --fix=../../jsfix.test_client.txt --delimiter=\"|\"  --session=../../data/session/test-initiator.json --objects",
     "parse-client-trade-captures": "node node_modules/jspurefix/dist/jsfix-cmd --fix=../../jsfix.test_client.txt --delimiter=\"|\"  --session=../../data/session/test-initiator.json --type=AE --objects",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "recovery:client": "node dist/trade_capture/app.js recovery --client",
     "broker-reset": "node dist/trade_capture/app.js broker-reset",
     "multi-client": "node dist/trade_capture/app.js multi-client --clients 3",
+    "dynamic": "node dist/trade_capture/app.js dynamic",
     "clear": "node dist/trade_capture/app.js clear",
     "scenarios": "bash scripts/test-scenarios.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -36,7 +37,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^15.0.0",
-    "jspurefix": "^5.8.5",
+    "jspurefix": "^5.9.1",
     "reflect-metadata": "^0.2.2"
   },
   "overrides": {

--- a/scripts/stale-transport.js
+++ b/scripts/stale-transport.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/*
+ * Reproduction driver for https://github.com/TimelordUK/jspurefix/issues/153.
+ *
+ * A counterparty logs on, then its socket goes half open - the peer is gone but no
+ * FIN or RST ever arrives, so the acceptor has no way to know.  The counterparty
+ * reconnects and logs on again with the same CompID.
+ *
+ * A real half open socket needs the network path to disappear (a firewall drop, a
+ * NAT timeout); killing a process does not produce one, because the kernel still
+ * closes its file descriptors.  So this script plays the counterparty itself: it
+ * opens a raw socket, sends a valid Logon, and then simply stops participating -
+ * never reading, never writing, never closing.  From the acceptor's point of view
+ * that is indistinguishable from the reported failure.
+ *
+ * A correct acceptor must end up with exactly one live session for the CompID, and
+ * it must be the new one.
+ *
+ * Usage: node scripts/stale-transport.js [--port 2345] [--sender init-comp]
+ */
+const net = require('net')
+
+const SOH = '\x01'
+
+function arg (name, fallback) {
+  const i = process.argv.indexOf(name)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const port = parseInt(arg('--port', '2345'), 10)
+const host = arg('--host', 'localhost')
+const sender = arg('--sender', 'init-comp')
+const target = arg('--target', 'accept-comp')
+
+function sendingTime () {
+  const d = new Date()
+  const p = (n, w = 2) => String(n).padStart(w, '0')
+  return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}-` +
+    `${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}.${p(d.getUTCMilliseconds(), 3)}`
+}
+
+/**
+ * Hand rolled so the script depends on nothing - the point is to behave like a
+ * counterparty the engine has no control over.  ResetSeqNumFlag=Y keeps the
+ * scenario repeatable against a persisted store.
+ */
+function logon (seqNum) {
+  const body = [
+    '35=A',
+    `49=${sender}`,
+    `56=${target}`,
+    `34=${seqNum}`,
+    '57=fix',
+    `52=${sendingTime()}`,
+    '98=0',
+    '108=30',
+    '141=Y',
+    '553=js-client',
+    '554=pwd-client'
+  ].join(SOH) + SOH
+
+  const head = `8=FIX4.4${SOH}9=${body.length}${SOH}`
+  const withoutChecksum = head + body
+  let sum = 0
+  for (let i = 0; i < withoutChecksum.length; ++i) sum += withoutChecksum.charCodeAt(i)
+  const checksum = String(sum % 256).padStart(3, '0')
+  return `${withoutChecksum}10=${checksum}${SOH}`
+}
+
+function connectAndLogon (label, { goSilent }) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, host, () => {
+      console.log(`[${label}] connected from ${socket.localAddress}:${socket.localPort}`)
+      socket.write(logon(1))
+      console.log(`[${label}] sent Logon for ${sender}`)
+      if (goSilent) {
+        // stop reading.  The socket stays open at the OS level and the process holds
+        // it, so the acceptor sees a peer that is connected but has stopped talking.
+        socket.pause()
+        console.log(`[${label}] going silent - socket held open, no further traffic`)
+      } else {
+        socket.on('data', (d) => {
+          const first = d.toString().split(SOH).find(f => f.startsWith('35='))
+          console.log(`[${label}] received ${first ?? '(partial)'}`)
+        })
+      }
+      resolve(socket)
+    })
+    socket.on('error', reject)
+  })
+}
+
+async function main () {
+  console.log(`stale transport scenario against ${host}:${port} as ${sender}`)
+
+  const stale = await connectAndLogon('client-1', { goSilent: true })
+  await new Promise(r => setTimeout(r, 3000))
+
+  console.log('')
+  console.log('--- counterparty reconnects on a fresh socket, same CompID ---')
+  const live = await connectAndLogon('client-2', { goSilent: false })
+  await new Promise(r => setTimeout(r, 5000))
+
+  console.log('')
+  console.log(`client-1 socket destroyed=${stale.destroyed} (the acceptor should have ended its session)`)
+  console.log(`client-2 socket destroyed=${live.destroyed} (should be false - this session is the live one)`)
+
+  stale.destroy()
+  live.destroy()
+}
+
+main().then(() => process.exit(0)).catch((e) => {
+  console.error(e.message)
+  process.exit(1)
+})

--- a/scripts/test-scenarios.sh
+++ b/scripts/test-scenarios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # jspf-demo Test Scenarios
-# Usage: ./scripts/test-scenarios.sh [client-bounce|server-bounce|broker-reset|multi-client|stale-transport|all]
+# Usage: ./scripts/test-scenarios.sh [client-bounce|server-bounce|broker-reset|multi-client|dynamic|stale-transport|all]
 #
 
 set -e
@@ -33,6 +33,7 @@ BROKER_CLIENT_SEQNUMS="$STORE_DIR/broker-initiator/FIX4.4-init-comp-accept-comp.
 BROKER_SERVER_SEQNUMS="$STORE_DIR/broker-acceptor/FIX4.4-accept-comp-init-comp.seqnums"
 MULTI_CLIENT_STORE="$STORE_DIR/multi-initiator"
 MULTI_SERVER_STORE="$STORE_DIR/multi-acceptor"
+DYNAMIC_SERVER_STORE="$STORE_DIR/dynamic-acceptor"
 
 get_sender_seq() { [ -f "$1" ] && awk -F':' '{print $1}' "$1" | tr -d ' ' || echo "0"; }
 
@@ -283,12 +284,51 @@ test_stale_transport() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# A venue configured with TargetCompID '*' and no knowledge of any counterparty.
+# Four unrelated names log on - one of them well after the venue started - and each
+# ends up with its own SessionId and its own persisted store.
+test_dynamic() {
+    print_banner "SCENARIO: Dynamic Acceptor (TargetCompID '*')"
+    echo "Counterparties the venue was never configured with log on and are adopted."
+
+    print_header "STEP 1: Clean Start"
+    clean_dir "$DYNAMIC_SERVER_STORE" "$STORE_DIR/dynamic-initiator"
+    print_success "Store cleaned"
+
+    print_header "STEP 2: Run venue with three counterparties, a fourth joining later"
+    local log="$STORE_DIR/dynamic.log"
+    $APP dynamic --timeout $((LONG_TIMEOUT * 2)) > "$log" 2>&1 || true
+
+    print_header "STEP 3: Which identities did the venue adopt?"
+    grep -oE "binding session identity to peer SenderCompID '[^']*'" "$log" | sed "s/^/  /" || true
+
+    print_header "STEP 4: Stores written, one per counterparty"
+    local stores
+    stores=$(ls "$DYNAMIC_SERVER_STORE"/*.seqnums 2>/dev/null | wc -l)
+    for f in "$DYNAMIC_SERVER_STORE"/*.seqnums; do
+        [ -f "$f" ] && echo "  $(basename "$f"): $(cat "$f")"
+    done
+
+    print_header "RESULT"
+    local configured
+    configured=$(grep -c "hedge-fund-a\|prop-desk-d" data/session/dynamic-acceptor.json || true)
+    if [ "$stores" -eq 4 ] && [ "$configured" -eq 0 ]; then
+        print_success "Four counterparties adopted, four stores, none named in the acceptor config"
+        return 0
+    else
+        print_error "Expected 4 stores and 0 configured names, got stores=$stores configured=$configured"
+        return 1
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 run_all() {
     local failures=0
     test_client_bounce || failures=$((failures + 1))
     test_server_bounce || failures=$((failures + 1))
     test_broker_reset  || failures=$((failures + 1))
     test_multi_client  || failures=$((failures + 1))
+    test_dynamic       || failures=$((failures + 1))
     test_stale_transport || failures=$((failures + 1))
     echo ""
     print_banner "SUMMARY"
@@ -306,7 +346,8 @@ case "$SCENARIO" in
     server-bounce)  test_server_bounce ;;
     broker-reset)   test_broker_reset ;;
     multi-client)   test_multi_client ;;
+    dynamic)        test_dynamic ;;
     stale-transport) test_stale_transport ;;
     all)            run_all ;;
-    *)  echo "Unknown: $SCENARIO (valid: client-bounce, server-bounce, broker-reset, multi-client, stale-transport, all)"; exit 1 ;;
+    *)  echo "Unknown: $SCENARIO (valid: client-bounce, server-bounce, broker-reset, multi-client, dynamic, stale-transport, all)"; exit 1 ;;
 esac

--- a/scripts/test-scenarios.sh
+++ b/scripts/test-scenarios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # jspf-demo Test Scenarios
-# Usage: ./scripts/test-scenarios.sh [client-bounce|server-bounce|broker-reset|all]
+# Usage: ./scripts/test-scenarios.sh [client-bounce|server-bounce|broker-reset|multi-client|stale-transport|all]
 #
 
 set -e
@@ -31,6 +31,8 @@ CLIENT_SEQNUMS="$STORE_DIR/initiator/FIX4.4-init-comp-accept-comp.seqnums"
 SERVER_SEQNUMS="$STORE_DIR/acceptor/FIX4.4-accept-comp-init-comp.seqnums"
 BROKER_CLIENT_SEQNUMS="$STORE_DIR/broker-initiator/FIX4.4-init-comp-accept-comp.seqnums"
 BROKER_SERVER_SEQNUMS="$STORE_DIR/broker-acceptor/FIX4.4-accept-comp-init-comp.seqnums"
+MULTI_CLIENT_STORE="$STORE_DIR/multi-initiator"
+MULTI_SERVER_STORE="$STORE_DIR/multi-acceptor"
 
 get_sender_seq() { [ -f "$1" ] && awk -F':' '{print $1}' "$1" | tr -d ' ' || echo "0"; }
 
@@ -203,11 +205,91 @@ test_broker_reset() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Multiple counterparties on one acceptor.  The acceptor runs TargetCompID '*', so
+# each accepted connection takes its identity - and its own store - from whichever
+# client logs on.  Before per-session isolation landed, all of them shared one
+# parse buffer, one description and one store file.
+test_multi_client() {
+    print_banner "SCENARIO: Multi Client Acceptor"
+    echo "Three clients connect concurrently to one wildcard acceptor."
+
+    print_header "STEP 1: Clean Start"
+    clean_dir "$MULTI_CLIENT_STORE" "$MULTI_SERVER_STORE"
+    print_success "Store cleaned"
+
+    print_header "STEP 2: Run acceptor with 3 clients"
+    run_quiet $APP multi-client --clients 3 --timeout $((LONG_TIMEOUT * 2))
+
+    print_header "STEP 3: Verify each client got its own session"
+    local server_stores client_stores
+    server_stores=$(ls "$MULTI_SERVER_STORE"/*.seqnums 2>/dev/null | wc -l)
+    client_stores=$(ls "$MULTI_CLIENT_STORE"/*.seqnums 2>/dev/null | wc -l)
+    print_info "acceptor side stores: $server_stores"
+    print_info "client side stores:   $client_stores"
+    for f in "$MULTI_SERVER_STORE"/*.seqnums; do
+        [ -f "$f" ] && echo "  $(basename "$f"): $(cat "$f")"
+    done
+
+    print_header "RESULT"
+    if [ "$server_stores" -eq 3 ] && [ "$client_stores" -eq 3 ]; then
+        print_success "Three independent sessions, three independent stores - no cross talk"
+        return 0
+    else
+        print_error "Expected 3 stores per side, got server=$server_stores client=$client_stores"
+        return 1
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# github.com/TimelordUK/jspurefix/issues/153 - a counterparty whose socket has gone
+# half open reconnects.  The acceptor must stop the stale session and keep the new
+# one, rather than running both against a single store.
+test_stale_transport() {
+    print_banner "SCENARIO: Stale Transport Replacement (issue #153)"
+    echo "Client goes silent without closing, then reconnects with the same CompID."
+
+    print_header "STEP 1: Clean Start"
+    clean_dir "$MULTI_SERVER_STORE"
+    print_success "Store cleaned"
+
+    print_header "STEP 2: Start acceptor"
+    local log="$STORE_DIR/stale-transport-server.log"
+    $APP multi-client --server --timeout $((LONG_TIMEOUT * 2)) > "$log" 2>&1 &
+    local server_pid=$!
+    sleep 3
+
+    print_header "STEP 3: Drive the half open reconnect"
+    node scripts/stale-transport.js || true
+
+    print_step "Stopping server..."
+    kill $server_pid 2>/dev/null; wait $server_pid 2>/dev/null || true
+
+    print_header "STEP 4: Verify the acceptor replaced the stale session"
+    local replaced remaining
+    replaced=$(grep -c "FOUND EXISTING SESSION" "$log" || true)
+    remaining=$(grep "acceptor census" "$log" | tail -1)
+    print_info "stale sessions replaced: $replaced"
+    print_info "final $remaining"
+
+    print_header "RESULT"
+    if [ "$replaced" -ge 1 ]; then
+        print_success "Stale session was stopped and replaced by the new connection"
+        grep -E "FOUND EXISTING SESSION|requestStop|successfully unregistered" "$log" | sed 's/^/  /'
+        return 0
+    else
+        print_error "Acceptor did not replace the stale session"
+        return 1
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 run_all() {
     local failures=0
     test_client_bounce || failures=$((failures + 1))
     test_server_bounce || failures=$((failures + 1))
     test_broker_reset  || failures=$((failures + 1))
+    test_multi_client  || failures=$((failures + 1))
+    test_stale_transport || failures=$((failures + 1))
     echo ""
     print_banner "SUMMARY"
     if [ $failures -eq 0 ]; then
@@ -223,6 +305,8 @@ case "$SCENARIO" in
     client-bounce)  test_client_bounce ;;
     server-bounce)  test_server_bounce ;;
     broker-reset)   test_broker_reset ;;
+    multi-client)   test_multi_client ;;
+    stale-transport) test_stale_transport ;;
     all)            run_all ;;
-    *)  echo "Unknown: $SCENARIO (valid: client-bounce, server-bounce, broker-reset, all)"; exit 1 ;;
+    *)  echo "Unknown: $SCENARIO (valid: client-bounce, server-bounce, broker-reset, multi-client, stale-transport, all)"; exit 1 ;;
 esac

--- a/src/trade_capture/app.ts
+++ b/src/trade_capture/app.ts
@@ -1,14 +1,17 @@
 import 'reflect-metadata'
 
+import * as fs from 'fs'
+import * as path from 'path'
+
 import { TradeCaptureServer } from './trade-capture-server'
 import { TradeCaptureClient } from './trade-capture-client'
-import { EngineFactory, IJsFixConfig, SessionLauncher } from 'jspurefix'
-import { getConfigPaths, parseCliOptions } from './cli'
+import { EngineFactory, IJsFixConfig, ISessionDescription, SessionLauncher } from 'jspurefix'
+import { CliOptions, getConfigPaths, parseCliOptions, storeDirectories } from './cli'
 
 class AppLauncher extends SessionLauncher {
   public constructor (
-    client: string | null,
-    server: string | null
+    client: string | ISessionDescription | null,
+    server: string | ISessionDescription | null
   ) {
     super(client, server)
     this.root = __dirname
@@ -17,31 +20,97 @@ class AppLauncher extends SessionLauncher {
   protected override makeFactory (config: IJsFixConfig): EngineFactory {
     const isInitiator = this.isInitiator(config.description)
     return {
-      makeSession: () => isInitiator
-        ? new TradeCaptureClient(config)
-        : new TradeCaptureServer(config)
+      // take the config handed to us rather than closing over the launcher's.  An
+      // acceptor resolves each accepted connection from its own scope, so this is
+      // that session's own description, store and message factory - without it
+      // every client on a multi-client acceptor would share one identity.
+      makeSession: (sessionConfig: IJsFixConfig) => isInitiator
+        ? new TradeCaptureClient(sessionConfig)
+        : new TradeCaptureServer(sessionConfig)
     } as EngineFactory
   }
 }
 
+function loadDescription (relativePath: string): any {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, relativePath), 'utf8'))
+}
+
+function withStore (description: any, store?: string): ISessionDescription {
+  if (store) {
+    description.store = { ...description.store, type: 'file', directory: store }
+  }
+  return description as ISessionDescription
+}
+
+/**
+ * Each client in a multi-client run needs its own SenderCompId, otherwise they all
+ * present the same identity and the acceptor's session registry - quite correctly -
+ * stops each one as the next logs on.  Mirrors the C# demo, which suffixes
+ * SenderCompID with _1.._n.
+ */
+function clientDescription (relativePath: string, index: number, total: number, store?: string): ISessionDescription {
+  const description = loadDescription(relativePath)
+  if (total > 1) {
+    description.SenderCompId = `${description.SenderCompId}_${index}`
+    description.application.name = `${description.application.name}_${index}`
+  }
+  return withStore(description, store)
+}
+
+function clearStores (): void {
+  storeDirectories.forEach(dir => {
+    const full = path.join(__dirname, '../..', dir)
+    if (fs.existsSync(full)) {
+      fs.rmSync(full, { recursive: true, force: true })
+      console.log(`cleared ${dir}`)
+    }
+  })
+  console.log('stores cleared')
+}
+
+function launch (opts: CliOptions): void {
+  const paths = getConfigPaths(opts)
+
+  console.log(`mode: ${opts.mode}, client: ${paths.client != null}, server: ${paths.server != null}, clients: ${opts.clients}`)
+  if (opts.store) console.log(`store override: ${opts.store}`)
+
+  if (opts.disconnectAfter != null) {
+    TradeCaptureClient.disconnectAfterSeconds = opts.disconnectAfter
+  }
+
+  const launchers: AppLauncher[] = []
+
+  // The acceptor gets its own launcher so it keeps listening after any one client
+  // goes away - a launcher given both roles ends when its client ends.
+  if (paths.server) {
+    launchers.push(new AppLauncher(null, withStore(loadDescription(paths.server), opts.store)))
+  }
+
+  if (paths.client) {
+    for (let i = 1; i <= opts.clients; ++i) {
+      launchers.push(new AppLauncher(clientDescription(paths.client, i, opts.clients, opts.store), null))
+    }
+  }
+
+  if (opts.timeout != null) {
+    setTimeout(() => {
+      console.log(`timeout after ${opts.timeout}s, shutting down`)
+      process.exit(0)
+    }, opts.timeout * 1000)
+  }
+
+  // stagger the starts so the acceptor is listening first, and so a multi-client
+  // run does not arrive as one connection storm
+  launchers.forEach((launcher, i) => {
+    setTimeout(() => {
+      launcher.exec()
+    }, i * 300)
+  })
+}
+
 const opts = parseCliOptions()
-const paths = getConfigPaths(opts)
-
-console.log(`mode: ${opts.mode}, client: ${paths.client != null}, server: ${paths.server != null}`)
-
-const launcher = new AppLauncher(paths.client, paths.server)
-
-// Apply disconnect-after if specified (for reconnect testing)
-if (opts.disconnectAfter != null) {
-  TradeCaptureClient.disconnectAfterSeconds = opts.disconnectAfter
+if (opts.mode === 'clear') {
+  clearStores()
+} else {
+  launch(opts)
 }
-
-// Apply timeout
-if (opts.timeout != null) {
-  setTimeout(() => {
-    console.log(`timeout after ${opts.timeout}s, shutting down`)
-    process.exit(0)
-  }, opts.timeout * 1000)
-}
-
-launcher.exec()

--- a/src/trade_capture/app.ts
+++ b/src/trade_capture/app.ts
@@ -6,7 +6,7 @@ import * as path from 'path'
 import { TradeCaptureServer } from './trade-capture-server'
 import { TradeCaptureClient } from './trade-capture-client'
 import { EngineFactory, IJsFixConfig, ISessionDescription, SessionLauncher } from 'jspurefix'
-import { CliOptions, getConfigPaths, parseCliOptions, storeDirectories } from './cli'
+import { CliOptions, getConfigPaths, lateCounterparty, parseCliOptions, storeDirectories } from './cli'
 
 class AppLauncher extends SessionLauncher {
   public constructor (
@@ -57,6 +57,66 @@ function clientDescription (relativePath: string, index: number, total: number, 
   return withStore(description, store)
 }
 
+/**
+ * A description for one named counterparty.  Only SenderCompId changes - the venue
+ * it is calling, the dictionary and the store directory are identical, which is the
+ * point: nothing about the acceptor is per counterparty either.
+ */
+function counterpartyDescription (relativePath: string, name: string, store?: string): ISessionDescription {
+  const description = loadDescription(relativePath)
+  description.SenderCompId = name
+  description.application.name = name
+  return withStore(description, store)
+}
+
+function storeDirFor (relativePath: string, override?: string): string {
+  return override ?? loadDescription(relativePath).store?.directory ?? 'store'
+}
+
+/**
+ * The whole point of the mode: show what the acceptor knew beforehand (nothing) and
+ * what it ends up holding (one identity, and one store, per counterparty).
+ */
+function describeDynamicRun (opts: CliOptions, acceptorPath: string): void {
+  const acceptor = loadDescription(acceptorPath)
+  const joiners = opts.counterparties
+  console.log('')
+  console.log('  dynamic acceptor')
+  console.log('  ────────────────')
+  console.log(`  the venue listens as SenderCompId '${acceptor.SenderCompId}' with TargetCompID '${acceptor.TargetCompID}',`)
+  console.log('  so it has no configuration for, and no prior knowledge of, any counterparty.')
+  console.log('')
+  console.log('  connecting at start:')
+  joiners.forEach(n => { console.log(`    ${n}`) })
+  if (opts.lateJoinAfter > 0) {
+    console.log(`  joining after ${opts.lateJoinAfter}s, with no restart of the venue:`)
+    console.log(`    ${lateCounterparty}`)
+  }
+  console.log('')
+  console.log('  each adopts its own SessionId on Logon, watch for:')
+  console.log("    'binding session identity to peer SenderCompID'")
+  console.log("    'acceptor census: ... sessions=[...]'")
+  console.log('')
+}
+
+/** what the venue ended up holding - one store per counterparty it met */
+function reportDynamicOutcome (acceptorPath: string, store?: string): void {
+  const dir = path.join(__dirname, '../..', storeDirFor(acceptorPath, store))
+  console.log('')
+  console.log('  the venue now holds a session store per counterparty it met:')
+  if (!fs.existsSync(dir)) {
+    console.log(`    (nothing under ${dir})`)
+    return
+  }
+  fs.readdirSync(dir).filter(f => f.endsWith('.seqnums')).sort().forEach(f => {
+    const seq = fs.readFileSync(path.join(dir, f), 'utf8').trim().replace(/\s+/g, ' ')
+    console.log(`    ${f}   [${seq}]`)
+  })
+  console.log('')
+  console.log('  none of those names appear anywhere in the acceptor configuration.')
+  console.log('')
+}
+
 function clearStores (): void {
   storeDirectories.forEach(dir => {
     const full = path.join(__dirname, '../..', dir)
@@ -73,6 +133,7 @@ function launch (opts: CliOptions): void {
 
   console.log(`mode: ${opts.mode}, client: ${paths.client != null}, server: ${paths.server != null}, clients: ${opts.clients}`)
   if (opts.store) console.log(`store override: ${opts.store}`)
+  if (opts.mode === 'dynamic' && paths.server) describeDynamicRun(opts, paths.server)
 
   if (opts.disconnectAfter != null) {
     TradeCaptureClient.disconnectAfterSeconds = opts.disconnectAfter
@@ -86,17 +147,39 @@ function launch (opts: CliOptions): void {
     launchers.push(new AppLauncher(null, withStore(loadDescription(paths.server), opts.store)))
   }
 
+  const dynamic = opts.mode === 'dynamic'
+
   if (paths.client) {
-    for (let i = 1; i <= opts.clients; ++i) {
-      launchers.push(new AppLauncher(clientDescription(paths.client, i, opts.clients, opts.store), null))
+    const clientConfigPath = paths.client
+    if (dynamic) {
+      opts.counterparties.forEach(name => {
+        launchers.push(new AppLauncher(counterpartyDescription(clientConfigPath, name, opts.store), null))
+      })
+    } else {
+      for (let i = 1; i <= opts.clients; ++i) {
+        launchers.push(new AppLauncher(clientDescription(paths.client, i, opts.clients, opts.store), null))
+      }
     }
   }
 
   if (opts.timeout != null) {
     setTimeout(() => {
+      if (dynamic && paths.server) reportDynamicOutcome(paths.server, opts.store)
       console.log(`timeout after ${opts.timeout}s, shutting down`)
       process.exit(0)
     }, opts.timeout * 1000)
+  }
+
+  // a counterparty the venue has never seen, arriving well after it started - no
+  // restart, no config change, it simply logs on and gets its own session
+  if (dynamic && paths.client && opts.lateJoinAfter > 0) {
+    const clientPath = paths.client
+    setTimeout(() => {
+      console.log('')
+      console.log(`  >>> previously unseen counterparty '${lateCounterparty}' is connecting now`)
+      console.log('')
+      new AppLauncher(counterpartyDescription(clientPath, lateCounterparty, opts.store), null).exec()
+    }, opts.lateJoinAfter * 1000)
   }
 
   // stagger the starts so the acceptor is listening first, and so a multi-client

--- a/src/trade_capture/cli.ts
+++ b/src/trade_capture/cli.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 
-export type SessionMode = 'reset' | 'recovery' | 'broker-reset'
+export type SessionMode = 'reset' | 'recovery' | 'broker-reset' | 'multi-client' | 'clear'
 
 export interface CliOptions {
   mode: SessionMode
@@ -8,13 +8,17 @@ export interface CliOptions {
   server: boolean
   timeout?: number
   disconnectAfter?: number
+  /** number of initiators to spawn, each with a unique SenderCompId suffix */
+  clients: number
+  /** override the store directory from the session config */
+  store?: string
 }
 
 /**
  * Config file pairs for each session mode.
  * Paths are relative to __dirname (dist/trade_capture/).
  */
-const modeConfigs: Record<SessionMode, { initiator: string, acceptor: string }> = {
+const modeConfigs: Record<Exclude<SessionMode, 'clear'>, { initiator: string, acceptor: string }> = {
   reset: {
     initiator: '../../data/session/test-initiator.json',
     acceptor: '../../data/session/test-acceptor.json'
@@ -26,10 +30,27 @@ const modeConfigs: Record<SessionMode, { initiator: string, acceptor: string }> 
   'broker-reset': {
     initiator: '../../data/session/broker-reset-initiator.json',
     acceptor: '../../data/session/broker-reset-acceptor.json'
+  },
+  // the acceptor here runs TargetCompID '*', so each accepted session takes its
+  // identity - and therefore its own store - from whichever client logs on
+  'multi-client': {
+    initiator: '../../data/session/multi-client-initiator.json',
+    acceptor: '../../data/session/multi-client-acceptor.json'
   }
 }
 
+/** store directories written by the modes above, emptied by `clear` */
+export const storeDirectories: string[] = [
+  'store/initiator',
+  'store/acceptor',
+  'store/broker-initiator',
+  'store/broker-acceptor',
+  'store/multi-initiator',
+  'store/multi-acceptor'
+]
+
 export function getConfigPaths (opts: CliOptions): { client: string | null, server: string | null } {
+  if (opts.mode === 'clear') return { client: null, server: null }
   const configs = modeConfigs[opts.mode]
   return {
     client: opts.server ? null : configs.initiator,
@@ -37,15 +58,19 @@ export function getConfigPaths (opts: CliOptions): { client: string | null, serv
   }
 }
 
+const validModes: SessionMode[] = ['reset', 'recovery', 'broker-reset', 'multi-client', 'clear']
+
 export function parseCliOptions (argv?: string[]): CliOptions {
   const program = new Command()
 
   program
     .name('jspf-demo')
     .description('jspurefix trade capture demo — reference application')
-    .argument('[mode]', 'session mode: reset (default), recovery, broker-reset', 'reset')
+    .argument('[mode]', `session mode: ${validModes.join(', ')}`, 'reset')
     .option('--client', 'run initiator (client) only')
     .option('--server', 'run acceptor (server) only')
+    .option('--clients <n>', 'number of clients to spawn, 1-5 (multi-client acceptor testing)', parseInt)
+    .option('--store <dir>', 'override the store directory from the session config')
     .option('--timeout <seconds>', 'shutdown after N seconds', parseInt)
     .option('--disconnect-after <seconds>', 'disconnect client after N seconds (reconnect testing)', parseInt)
 
@@ -58,9 +83,19 @@ export function parseCliOptions (argv?: string[]): CliOptions {
     process.exit(1)
   }
 
-  const validModes: SessionMode[] = ['reset', 'recovery', 'broker-reset']
   if (!validModes.includes(mode)) {
     console.error(`error: unknown mode '${mode}'. Valid modes: ${validModes.join(', ')}`)
+    process.exit(1)
+  }
+
+  const clients = opts.clients ?? 1
+  if (!Number.isInteger(clients) || clients < 1 || clients > 5) {
+    console.error('error: --clients must be an integer between 1 and 5')
+    process.exit(1)
+  }
+
+  if (clients > 1 && opts.server === true) {
+    console.error('error: --clients has no meaning with --server (the acceptor does not spawn clients)')
     process.exit(1)
   }
 
@@ -69,6 +104,8 @@ export function parseCliOptions (argv?: string[]): CliOptions {
     client: opts.client ?? false,
     server: opts.server ?? false,
     timeout: opts.timeout,
-    disconnectAfter: opts.disconnectAfter
+    disconnectAfter: opts.disconnectAfter,
+    clients,
+    store: opts.store
   }
 }

--- a/src/trade_capture/cli.ts
+++ b/src/trade_capture/cli.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 
-export type SessionMode = 'reset' | 'recovery' | 'broker-reset' | 'multi-client' | 'clear'
+export type SessionMode = 'reset' | 'recovery' | 'broker-reset' | 'multi-client' | 'dynamic' | 'clear'
 
 export interface CliOptions {
   mode: SessionMode
@@ -12,7 +12,25 @@ export interface CliOptions {
   clients: number
   /** override the store directory from the session config */
   store?: string
+  /** dynamic mode: the counterparties to connect, none known to the acceptor */
+  counterparties: string[]
+  /** dynamic mode: seconds before the late joiner connects, 0 to disable */
+  lateJoinAfter: number
 }
+
+/**
+ * Counterparties for `dynamic` mode.  Deliberately unrelated names - the point is
+ * that the acceptor is configured with TargetCompID '*' and has never heard of any
+ * of them until they log on.
+ */
+export const defaultCounterparties: string[] = [
+  'hedge-fund-a',
+  'market-maker-b',
+  'retail-broker-c'
+]
+
+/** joins after the others, to show the acceptor needs no restart to take a new one */
+export const lateCounterparty = 'prop-desk-d'
 
 /**
  * Config file pairs for each session mode.
@@ -36,6 +54,13 @@ const modeConfigs: Record<Exclude<SessionMode, 'clear'>, { initiator: string, ac
   'multi-client': {
     initiator: '../../data/session/multi-client-initiator.json',
     acceptor: '../../data/session/multi-client-acceptor.json'
+  },
+  // same wildcard acceptor, but the counterparties are unrelated names the venue
+  // has never been configured with - the point of the mode is that it does not
+  // need to know them in advance
+  dynamic: {
+    initiator: '../../data/session/dynamic-initiator.json',
+    acceptor: '../../data/session/dynamic-acceptor.json'
   }
 }
 
@@ -46,7 +71,9 @@ export const storeDirectories: string[] = [
   'store/broker-initiator',
   'store/broker-acceptor',
   'store/multi-initiator',
-  'store/multi-acceptor'
+  'store/multi-acceptor',
+  'store/dynamic-initiator',
+  'store/dynamic-acceptor'
 ]
 
 export function getConfigPaths (opts: CliOptions): { client: string | null, server: string | null } {
@@ -58,7 +85,7 @@ export function getConfigPaths (opts: CliOptions): { client: string | null, serv
   }
 }
 
-const validModes: SessionMode[] = ['reset', 'recovery', 'broker-reset', 'multi-client', 'clear']
+const validModes: SessionMode[] = ['reset', 'recovery', 'broker-reset', 'multi-client', 'dynamic', 'clear']
 
 export function parseCliOptions (argv?: string[]): CliOptions {
   const program = new Command()
@@ -70,6 +97,8 @@ export function parseCliOptions (argv?: string[]): CliOptions {
     .option('--client', 'run initiator (client) only')
     .option('--server', 'run acceptor (server) only')
     .option('--clients <n>', 'number of clients to spawn, 1-5 (multi-client acceptor testing)', parseInt)
+    .option('--counterparties <names>', 'dynamic mode: comma separated SenderCompIds to connect')
+    .option('--late-join-after <seconds>', 'dynamic mode: seconds before a previously unseen counterparty joins, 0 to disable', parseInt)
     .option('--store <dir>', 'override the store directory from the session config')
     .option('--timeout <seconds>', 'shutdown after N seconds', parseInt)
     .option('--disconnect-after <seconds>', 'disconnect client after N seconds (reconnect testing)', parseInt)
@@ -99,6 +128,15 @@ export function parseCliOptions (argv?: string[]): CliOptions {
     process.exit(1)
   }
 
+  const counterparties: string[] = opts.counterparties
+    ? String(opts.counterparties).split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
+    : defaultCounterparties
+
+  if (counterparties.length === 0) {
+    console.error('error: --counterparties needs at least one name')
+    process.exit(1)
+  }
+
   return {
     mode,
     client: opts.client ?? false,
@@ -106,6 +144,8 @@ export function parseCliOptions (argv?: string[]): CliOptions {
     timeout: opts.timeout,
     disconnectAfter: opts.disconnectAfter,
     clients,
-    store: opts.store
+    store: opts.store,
+    counterparties,
+    lateJoinAfter: opts.lateJoinAfter ?? 8
   }
 }

--- a/src/trade_capture/trade-capture-server.ts
+++ b/src/trade_capture/trade-capture-server.ts
@@ -69,6 +69,15 @@ export class TradeCaptureServer extends AsciiSession {
   }
 
   protected onLogon (view: MsgView, user: string, password: string): boolean {
+    // On a wildcard acceptor (TargetCompID '*') this is the moment the session
+    // learns who it is talking to.  The engine has already adopted the peer's
+    // SenderCompID as this session's target by the time onLogon runs, so the
+    // description below is this session's own - not the listener's template.
+    const peer = view.getTyped(MsgTag.SenderCompID) as string
+    const isWildcardVenue = this.config.description.TargetCompID === peer
+    this.logger.info(isWildcardVenue
+      ? `accepted counterparty '${peer}' (user ${user}) - session is now ${this.config.description.SenderCompId} -> ${peer}`
+      : `accepted logon from '${peer}' (user ${user})`)
     return true
   }
 


### PR DESCRIPTION
Brings the demo onto the published 5.9.1 engine and adds the modes that show off what landed there.

## `dynamic` — the mode to run

The acceptor is configured as a venue and nothing else:

```json
{
  "SenderCompId": "venue",
  "TargetCompID": "*"
}
```

No counterparty is named anywhere in its configuration. Four unrelated names log on — three at startup, and `prop-desk-d` eight seconds later with no restart and no config change:

```
wildcard acceptor: binding session identity to peer SenderCompID 'hedge-fund-a'
accepted counterparty 'hedge-fund-a' (user js-client) - session is now venue -> hedge-fund-a
...
  >>> previously unseen counterparty 'prop-desk-d' is connecting now
wildcard acceptor: binding session identity to peer SenderCompID 'prop-desk-d'
```

and the venue ends the run holding a persisted session per counterparty it met:

```
  the venue now holds a session store per counterparty it met:
    FIX4.4-venue-hedge-fund-a.seqnums     [15 : 4]
    FIX4.4-venue-market-maker-b.seqnums   [16 : 4]
    FIX4.4-venue-prop-desk-d.seqnums      [15 : 4]
    FIX4.4-venue-retail-broker-c.seqnums  [14 : 4]

  none of those names appear anywhere in the acceptor configuration.
```

Each of those is a full FIX session — own sequence numbers, own resend history, recovered independently on reconnect. That is the distinction worth demonstrating: a wildcard that only rewrites the outbound header would leave all four sharing one store.

`TradeCaptureServer.onLogon` does nothing but log. No `addCompIdMapping`, no per-counterparty wiring — adopting the identity is the engine's job now.

## Why a separate mode from `multi-client`

`multi-client` spawns `init-comp_1..3` — suffixed clones of one name. It proves isolation, but it reads like replication rather than discovery, and it does not answer "what if I do not know my counterparties in advance". `dynamic` answers exactly that, and keeps `multi-client` as the focused isolation test.

## Also in here

- `--counterparties acme-capital,zeta-trading` to bring your own names; `--late-join-after 0` to disable the late joiner
- `--clients <n>`, `--store <dir>`, `clear` mode
- scenarios `multi-client`, `dynamic`, `stale-transport` (the last drives a raw socket that logs on then stops participating — reproducing jspurefix#153, since killing a process cannot produce a half-open socket)
- `use:local` / `use:npm` to swap between a locally packed engine and the registry version
- generated FIX logs ignored generally, now that they are named per counterparty

## Verification

All on published jspurefix 5.9.1, not a local tarball:

- `dynamic` — four adopted identities, four stores, zero counterparty names in the acceptor config
- `multi-client` — three sessions, three stores, no cross talk
- `stale-transport` — stale session stopped and replaced
- `client-bounce`, `broker-reset` — still pass
- build and lint clean

**Known failure, unchanged and pre-existing:** `server-bounce` does not pass, and does not pass on 5.8.5 either. The acceptor's persisted sender sequence lags what it actually sent, because the store write in `txOnEncoded` is fire and forget; on restart the client sees a sequence below what it recorded and drops the session. Documented in the README and tracked as its own phase in the engine's `BACKPORT_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
