### PR TITLE
Fix server-bounce scenario: it was starting two servers on one port

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,15 @@ asserting on the persisted sequence files afterwards.
 ./scripts/test-scenarios.sh all
 ```
 
+All six pass. If you are adding a scenario, note `run_quiet_bg` publishes the pid in
+`BG_PID` rather than echoing it — assigning it via command substitution runs the
+function in a subshell, so `$!` is a pid the calling shell does not own and `wait`
+on it fails instantly instead of blocking.
+
 `stale-transport` uses `scripts/stale-transport.js`, which plays the counterparty
 directly over a raw socket: it logs on, then stops participating without ever
 closing. Killing a process would not reproduce this — the kernel still closes its
 file descriptors — so the script holds the socket open itself.
-
-**Known failure:** `server-bounce` does not currently pass. The acceptor's persisted
-sender sequence lags what it actually sent (message store writes are fire and
-forget), so on restart the client sees a sequence number below what it has already
-recorded and drops the session. This reproduces on published jspurefix 5.8.5 too,
-so it is not a regression from the multi-client work — it needs a separate fix in
-the engine's store flush path.
 
 ## Working against an unpublished jspurefix
 

--- a/scripts/test-scenarios.sh
+++ b/scripts/test-scenarios.sh
@@ -25,7 +25,14 @@ print_error()   { echo -e "${RED}✗ $1${NC}"; }
 print_info()    { echo -e "${BLUE}  $1${NC}"; }
 
 run_quiet() { "$@" > /dev/null 2>&1; }
-run_quiet_bg() { "$@" > /dev/null 2>&1 & echo $!; }
+# Start a background job and publish its pid in BG_PID.
+#
+# Deliberately not assigned via command substitution: that runs the function
+# in a subshell, so $! is a pid the calling shell does not own.  `wait` on it fails
+# immediately with "not a child of this shell" - which silently turned every
+# "wait for the server to finish" into a no-op, and left servers running that the
+# next step then tried to start a second copy of on the same port.
+run_quiet_bg() { "$@" > /dev/null 2>&1 & BG_PID=$!; }
 
 CLIENT_SEQNUMS="$STORE_DIR/initiator/FIX4.4-init-comp-accept-comp.seqnums"
 SERVER_SEQNUMS="$STORE_DIR/acceptor/FIX4.4-accept-comp-init-comp.seqnums"
@@ -59,7 +66,7 @@ test_client_bounce() {
     print_success "Store cleaned"
 
     print_header "STEP 2: Start Server (long running)"
-    SERVER_PID=$(run_quiet_bg $APP recovery --server --timeout $((LONG_TIMEOUT * 3)))
+    run_quiet_bg $APP recovery --server --timeout $((LONG_TIMEOUT * 3)); SERVER_PID=$BG_PID
     sleep 2
 
     print_header "STEP 3: First Client Session (${SHORT_TIMEOUT}s)"
@@ -110,9 +117,9 @@ test_server_bounce() {
     print_success "Store cleaned"
 
     print_header "STEP 2: Initial Session (server runs ${LONG_TIMEOUT}s)"
-    SERVER_PID=$(run_quiet_bg $APP recovery --server --timeout $LONG_TIMEOUT)
+    run_quiet_bg $APP recovery --server --timeout $LONG_TIMEOUT; SERVER_PID=$BG_PID
     sleep 2
-    CLIENT_PID=$(run_quiet_bg $APP recovery --client --timeout $((LONG_TIMEOUT + 5)))
+    run_quiet_bg $APP recovery --client --timeout $((LONG_TIMEOUT + 5)); CLIENT_PID=$BG_PID
 
     print_info "Waiting for server to timeout..."
     wait $SERVER_PID 2>/dev/null || true
@@ -129,9 +136,9 @@ test_server_bounce() {
     sleep 3
 
     print_header "STEP 5: Restart Both"
-    SERVER_PID=$(run_quiet_bg $APP recovery --server --timeout $LONG_TIMEOUT)
+    run_quiet_bg $APP recovery --server --timeout $LONG_TIMEOUT; SERVER_PID=$BG_PID
     sleep 2
-    CLIENT_PID=$(run_quiet_bg $APP recovery --client --timeout $SHORT_TIMEOUT)
+    run_quiet_bg $APP recovery --client --timeout $SHORT_TIMEOUT; CLIENT_PID=$BG_PID
 
     wait $SERVER_PID 2>/dev/null || true
     wait $CLIENT_PID 2>/dev/null || true
@@ -166,7 +173,7 @@ test_broker_reset() {
     print_success "Store cleaned"
 
     print_header "STEP 2: First Session — Build Up Sequences"
-    SERVER_PID=$(run_quiet_bg $APP broker-reset --server --timeout $LONG_TIMEOUT)
+    run_quiet_bg $APP broker-reset --server --timeout $LONG_TIMEOUT; SERVER_PID=$BG_PID
     sleep 2
     run_quiet $APP broker-reset --client --timeout $SHORT_TIMEOUT
     sleep 1
@@ -182,7 +189,7 @@ test_broker_reset() {
     sleep 3
 
     print_header "STEP 5: Reconnect — Server Forces Reset"
-    SERVER_PID=$(run_quiet_bg $APP broker-reset --server --timeout $LONG_TIMEOUT)
+    run_quiet_bg $APP broker-reset --server --timeout $LONG_TIMEOUT; SERVER_PID=$BG_PID
     sleep 2
     run_quiet $APP broker-reset --client --timeout $SHORT_TIMEOUT
     sleep 1


### PR DESCRIPTION
`test_server_bounce` never passed. I had recorded it as an engine bug — a fire-and-forget store write leaving the acceptor's persisted sender sequence behind what it sent. **That diagnosis was wrong.** Reproducing the run by hand disproved it, and the real cause is in the harness.

## What was happening

```bash
run_quiet_bg() { "$@" > /dev/null 2>&1 & echo $!; }
SERVER_PID=$(run_quiet_bg $APP recovery --server --timeout $LONG_TIMEOUT)
...
wait $SERVER_PID 2>/dev/null || true
```

Command substitution runs the function in a subshell, so `$!` is a pid the calling shell does not own:

```
$ PID=$(run_quiet_bg sleep 6)
$ wait $PID
bash: wait: pid 3658 is not a child of this shell
wait blocked for 0s (expected 6 if it really waited)
  ...and the process is STILL RUNNING
```

So "wait for the server to time out" was a no-op. The first server was still alive and still bound to 2345 when step 5 started a second one, and the phase 2 client had nothing to talk to — hence sequences that never progressed. The `2>/dev/null || true` meant it never surfaced.

`run_quiet_bg` now publishes `BG_PID` in the caller's shell.

## The engine was fine

Running the two phases by hand, with the scenario's exact timings:

```
after phase 1:  client 4 : 14    server 14 : 4     ← stores agree exactly
after phase 2:  client 7 : 27    server 27 : 7     ← resumed and traded
```

Both sides recover from the file store correctly, including with the tight 5-second client budget step 5 uses. There was never a store-flush bug — my note claimed the acceptor's store lagged what it sent, and it does not.

## Result

```
✓ Client Bounce Recovery
✓ Server Bounce Recovery          ← now passes
✓ Broker Controlled Reset
✓ Multi Client Acceptor
✓ Dynamic Acceptor (TargetCompID '*')
✓ Stale Transport Replacement (issue #153)
✓ All scenarios passed
```

Removes the incorrect "known failure" note from the README and replaces it with a warning about the `BG_PID` convention for anyone adding a scenario. The matching note in the engine's `BACKPORT_PLAN.md` is corrected separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
