### PR TITLE
fix: end a run once every client has finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ node dist/trade_capture/app.js recovery --server --timeout 30
 node dist/trade_capture/app.js multi-client --clients 3 --timeout 25
 ```
 
+### When a run ends
+
+A FIX acceptor is meant to outlive its counterparties, so nothing closes its listener
+when a session ends — and a listening socket keeps node alive on its own, however
+quiet the log has gone. Every mode here therefore says which it is doing:
+
+- **both roles in one process** (the default for every mode) — when every client this
+  run will ever have has logged out, there is nothing left to serve, so the demo
+  closes the listener and the process ends by itself. `dynamic` waits for its late
+  joiner too, then prints what the venue ended up holding.
+
+  ```
+  all clients finished, stopping acceptor
+  [acceptor] info: acceptor closed.
+  ```
+
+- **`--server`, or `--disconnect-after`** — the acceptor is deliberately left
+  listening: in the first case the clients are other processes, and in the second the
+  whole point is to watch the acceptor survive a client going away.
+
+  ```
+  acceptor keeps listening - ctrl-c, or --timeout <seconds>, to end the run
+  ```
+
+`--timeout <seconds>` still means what it says in either case: the listener is closed
+properly and the process exits at N seconds.
+
 ## Dynamic acceptor — counterparties known only at logon
 
 `dynamic` mode is the one to run if you want to see what `TargetCompID: "*"` buys

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "commander": "^15.0.0",
-        "jspurefix": "^5.10.0",
+        "jspurefix": "^5.10.2",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
@@ -7234,9 +7234,9 @@
       "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ=="
     },
     "node_modules/jspurefix": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jspurefix/-/jspurefix-5.10.0.tgz",
-      "integrity": "sha512-SLuQ5HFeb+03A5xwqxxqGBz4/WeRLIq2cdN/RjyB/TQLrfO/y8DLjRc+5rtz85iFRm7kJ/Yl6+AxSS1lquEs0A==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/jspurefix/-/jspurefix-5.10.2.tgz",
+      "integrity": "sha512-4aZd1YIkbcgalbgdMEUdy5N635LavBc2AENof1QlU0uECk+Ui1PI+yyFTCqPO9wtn8BcDfpzwb0lVuUVoMw8xg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^15.0.0",
-    "jspurefix": "^5.10.0",
+    "jspurefix": "^5.10.2",
     "reflect-metadata": "^0.2.2"
   },
   "overrides": {

--- a/src/trade_capture/app.ts
+++ b/src/trade_capture/app.ts
@@ -197,59 +197,118 @@ function launch (opts: CliOptions): void {
     TradeCaptureClient.disconnectAfterSeconds = opts.disconnectAfter
   }
 
-  const launchers: AppLauncher[] = []
-
   // The acceptor gets its own launcher so it keeps listening after any one client
   // goes away - a launcher given both roles ends when its client ends.
-  if (paths.server) {
-    const description = withDictionary(withStore(loadDescription(paths.server), opts.store), dictionary)
-    launchers.push(new AppLauncher(null, description, bespokeLogon))
-  }
+  const acceptor: AppLauncher | null = paths.server
+    ? new AppLauncher(
+      null, withDictionary(withStore(loadDescription(paths.server), opts.store), dictionary), bespokeLogon)
+    : null
 
   const dynamic = opts.mode === 'dynamic'
+  const clientLaunchers: AppLauncher[] = []
 
   if (paths.client) {
     const clientConfigPath = paths.client
     if (dynamic) {
       opts.counterparties.forEach(name => {
-        launchers.push(new AppLauncher(counterpartyDescription(clientConfigPath, name, opts.store), null))
+        clientLaunchers.push(new AppLauncher(counterpartyDescription(clientConfigPath, name, opts.store), null))
       })
     } else {
       for (let i = 1; i <= opts.clients; ++i) {
         const description = withDictionary(
           clientDescription(paths.client, i, opts.clients, opts.store), dictionary)
-        launchers.push(new AppLauncher(description, null, bespokeLogon))
+        clientLaunchers.push(new AppLauncher(description, null, bespokeLogon))
       }
     }
+  }
+
+  // stagger the starts so the acceptor is listening first, and so a multi-client
+  // run does not arrive as one connection storm
+  let slot = 0
+  // the acceptor's own run only ends when its listener closes, below
+  const acceptorRun = acceptor ? start(acceptor, slot++ * staggerMs) : null
+  // one entry per client this run will ever have, each settling when that client's
+  // session ends - the late joiner takes its slot now, though it connects later
+  const clientRuns: Array<Promise<void>> = clientLaunchers.map(async l => { await start(l, slot++ * staggerMs) })
+
+  // a counterparty the venue has never seen, arriving well after it started - no
+  // restart, no config change, it simply logs on and gets its own session
+  if (dynamic && paths.client && opts.lateJoinAfter > 0) {
+    const clientPath = paths.client
+    clientRuns.push((async () => {
+      await delay(opts.lateJoinAfter * 1000)
+      console.log('')
+      console.log(`  >>> previously unseen counterparty '${lateCounterparty}' is connecting now`)
+      console.log('')
+      await start(new AppLauncher(counterpartyDescription(clientPath, lateCounterparty, opts.store), null), 0)
+    })())
   }
 
   if (opts.timeout != null) {
     setTimeout(() => {
       if (dynamic && paths.server) reportDynamicOutcome(paths.server, opts.store)
       console.log(`timeout after ${opts.timeout}s, shutting down`)
-      process.exit(0)
+      // close the listener properly rather than letting the exit tear it down, but
+      // still guarantee what --timeout promises: this process is gone at N seconds
+      acceptor?.stop()
+      setTimeout(() => { process.exit(0) }, 250)
     }, opts.timeout * 1000)
   }
 
-  // a counterparty the venue has never seen, arriving well after it started - no
-  // restart, no config change, it simply logs on and gets its own session
-  if (dynamic && paths.client && opts.lateJoinAfter > 0) {
-    const clientPath = paths.client
-    setTimeout(() => {
-      console.log('')
-      console.log(`  >>> previously unseen counterparty '${lateCounterparty}' is connecting now`)
-      console.log('')
-      new AppLauncher(counterpartyDescription(clientPath, lateCounterparty, opts.store), null).exec()
-    }, opts.lateJoinAfter * 1000)
+  if (acceptor && acceptorRun) {
+    shutdownWhenClientsDone(acceptor, acceptorRun, clientRuns, opts, paths, dynamic)
   }
+}
 
-  // stagger the starts so the acceptor is listening first, and so a multi-client
-  // run does not arrive as one connection storm
-  launchers.forEach((launcher, i) => {
-    setTimeout(() => {
-      launcher.exec()
-    }, i * 300)
-  })
+/** start a launcher after a delay, resolving when whatever it started has ended */
+async function start (launcher: AppLauncher, delayMs: number): Promise<void> {
+  await delay(delayMs)
+  try {
+    await launcher.run()
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+async function delay (ms: number): Promise<void> {
+  await new Promise<void>(resolve => { setTimeout(resolve, ms) })
+}
+
+const staggerMs = 300
+
+/**
+ * An acceptor outlives any one client - that is the whole reason it has a launcher of
+ * its own, and why nothing closes its listener when a session ends.  But once every
+ * client this run will ever have has finished there is nothing left to serve, and the
+ * listening socket is then the only thing holding the process open: the run appears to
+ * hang long after the logs say everything shut down.
+ *
+ * So close it, and node exits by itself.  Two runs are deliberately left listening:
+ *   --server, where the clients are other processes and this one is the venue
+ *   --disconnect-after, whose entire point is to watch the acceptor survive a client
+ * both of which say so rather than leaving anyone guessing.
+ */
+function shutdownWhenClientsDone (
+  acceptor: AppLauncher,
+  acceptorRun: Promise<void>,
+  clientRuns: Array<Promise<void>>,
+  opts: CliOptions,
+  paths: { server: string | null },
+  dynamic: boolean): void {
+  if (clientRuns.length === 0 || opts.disconnectAfter != null) {
+    console.log('acceptor keeps listening - ctrl-c, or --timeout <seconds>, to end the run')
+    return
+  }
+  void (async () => {
+    await Promise.all(clientRuns)
+    console.log('all clients finished, stopping acceptor')
+    acceptor.stop()
+    // the launcher's run resolves once the listener has actually closed, by which
+    // time each accepted session has written its sequence numbers - report after
+    // that, or the venue appears to hold an empty store for its last counterparty
+    await acceptorRun
+    if (dynamic && paths.server) reportDynamicOutcome(paths.server, opts.store)
+  })()
 }
 
 const opts = parseCliOptions()


### PR DESCRIPTION
A run never exited.  Every session logged out, every transport was harvested, the census read transports=0 sessions=0 - and the process sat there.  The acceptor's listening socket keeps node alive on its own, and nothing closed it.

That was a regression from the multi-client work: giving the acceptor a launcher of its own, so it survives any one client going away, took the run out of the engine's both-roles path - the only place that stopped an acceptor when its client finished.

So do it here, where the application knows.  Clients now start via run() rather than exec(), so the app holds one promise per client this run will ever have, the dynamic late joiner included - its slot is taken up front though it connects later.  When they have all settled the acceptor is stopped, and node exits by itself.

Two runs are deliberately left listening, and now say so rather than looking hung: --server, where the clients are other processes, and --disconnect-after, whose whole point is watching the acceptor survive a client.  --timeout still exits at N, closing the listener properly on the way rather than letting process.exit tear it down.

Dynamic mode's store report moves after the listener closes.  It used to run only on --timeout; on the default path it showed the late joiner's store as empty, because it read the directory before the acceptor side had flushed.  All four counterparties now report real sequence numbers.

Needs jspurefix 5.10.2 for the public SessionLauncher.stop().

Verified: custom-logon 34s, multi-client --clients 3 34s, dynamic 41s, all exit 0; --server and --disconnect-after keep listening as intended; all six scenarios in test-scenarios.sh pass.