### PR TITLE
chore: 1.14.0, on jspurefix 5.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "jspf-demo",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jspf-demo",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "license": "ISC",
       "dependencies": {
         "commander": "^15.0.0",
-        "jspurefix": "^5.11.0",
+        "jspurefix": "^5.11.1",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspf-demo",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "",
   "main": "dist/trade_capture/app.js",
   "homepage": "https://github.com/TimelordUK/jspf-demo",
@@ -44,7 +44,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^15.0.0",
-    "jspurefix": "^5.11.0",
+    "jspurefix": "^5.11.1",
     "reflect-metadata": "^0.2.2"
   },
   "overrides": {


### PR DESCRIPTION
Version bump following #30, now that 5.11.1 is on npm.

- **1.13.2 → 1.14.0.** Minor rather than patch: `--resilient`, `--drop-after`, `--retry-every` and `--give-up-after` are new flags.
- **jspurefix `^5.11.0` → `^5.11.1`.** The README documents the connect failure reason reaching the application, which is what 5.11.1 added (jspurefix#182). The old range would have resolved to it anyway, but the floor should say what the demo actually needs.

Both scenarios re-run against the **published** package rather than the local bundle they were developed against:

```
skeleton_client: retries 1 connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349
skeleton_client: giving up after 6s and 2 retries, last error: connect ECONNREFUSED ...
[launcher] error: connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349 : AggregateError [ECONNREFUSED]
```

```
[server] dropping the client - a resilient initiator should get itself back
recover session transport - attempt in 3 secs
connect: receive new transport 0
[client] session ready - heartbeat only        <-- second time, same session
```

Build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
