### PR TITLE
ci: add dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Every advisory this repo has seen so far has been in the dev toolchain
+  # (eslint, ts-jest, madge), so group those into a single weekly PR rather
+  # than taking one PR per transitive bump.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      prod-dependencies:
+        dependency-type: production
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Follow-up to #33, which cleared 10 dev-scoped advisories by hand. This makes the next sweep arrive as a PR instead.

**npm** - weekly, grouped into two PRs (`dev-dependencies` / `prod-dependencies`). Grouping is the point: every advisory this repo has seen has been transitive through eslint, ts-jest or madge, and ungrouped the #33 sweep would have landed as roughly six separate PRs.

**github-actions** - monthly, all actions grouped. `build.yml` pins `actions/checkout@v4` and `actions/setup-node@v4`; this keeps them current.

Commit prefixes are set to `chore` / `ci` to match the existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)