### PR TITLE
ci: run lint in CI, ignore eslint and typescript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,19 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # eslint-config-love 155 (latest) still declares peer eslint@^9.35.0, so
+      # eslint 10 cannot install at all - npm fails to resolve. Lift this once
+      # eslint-config-love supports eslint 10.
+      - dependency-name: eslint
+        update-types: [version-update:semver-major]
+      # typescript-eslint refuses to load against TS 7.0, and the typescript
+      # override below forces our version into its resolution too, so the
+      # documented side-by-side TS 6 arrangement is not available to us. tsc 7
+      # itself builds this project fine. Lift once typescript-eslint supports
+      # TS >=7.1 - https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
     groups:
       dev-dependencies:
         dependency-type: development

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Install dependencies
       run: npm install
 
+    - name: Lint
+      run: npm run lint
+
     - name: Build
       run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint": "eslint src --max-warnings=0",
     "use:local": "npm install \"../.local-packages/jspurefix-local.tgz\"",
     "use:npm": "npm install jspurefix@latest",
     "tcp-tc": "node dist/trade_capture/app.js",


### PR DESCRIPTION
Two things #36 exposed.

**CI never ran lint.** `build.yml` runs `npm install`, `tsc` and the demo - so a toolchain that installs and compiles but cannot lint passes CI clean. That is exactly the typescript 7 situation in #36: `tsc 7.0.2` builds this project fine, while typescript-eslint refuses to load against it. Adds a `Lint` step between install and build, plus the `npm run lint` script it calls (`eslint src --max-warnings=0`).

**Two majors are blocked upstream**, so dependabot should stop proposing them until that changes. Both ignores are commented with the blocker and the condition for lifting:

| Ignored | Blocker | Lift when |
| --- | --- | --- |
| eslint major | eslint-config-love 155 (latest) peers `eslint@^9.35.0` - npm cannot resolve eslint 10 at all | config-love supports eslint 10 |
| typescript major | typescript-eslint does not load against TS 7.0; our `overrides: { typescript: "$typescript" }` forces it into typescript-eslint too, so the documented side-by-side TS 6 API arrangement is not open to us | [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) lands TS >=7.1 support |

Minors and patches for both still come through as normal - only majors are held.

Verified `npm run lint` exits 0 on the current toolchain (eslint 9.39.4, eslint-config-love 151, typescript 6.0.3), so this does not land master red. Both YAML files parse.

Pairs with #38, which takes the one bump from #36 that does work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)